### PR TITLE
Update gltext.h to remove the black text backgrnd

### DIFF
--- a/gltext.h
+++ b/gltext.h
@@ -859,7 +859,9 @@ static const GLchar* _gltText2DFragmentShaderSource =
 "\n"
 "void main()\n"
 "{\n"
-"	fragColor = texture(diffuse, fTexCoord) * color;\n"
+"	fragColor = texture(diffuse, fTexCoord);\n"
+"	if(fragColor.a<0.5 || length(fragColor.rgb) < 0.5){discard;}\n"
+"   	fragColor *= color;"
 "}\n";
 
 GLT_API GLboolean _gltCreateText2DShader(void)


### PR DESCRIPTION
Added check to make discard alpha pixels and shadow pixels. 

When the glyph is created, it automatically comes with a black shadow, as well as a transparent background. This code uses two checks: the first removes the transparent background, and the second removes the black shadow. Adding in a different colored background, and adding options for whether to have a text shadow, should be trivial from here.