### PR TITLE
Fixed glVertexAttribPointer not being set before drawing

### DIFF
--- a/gltext.h
+++ b/gltext.h
@@ -394,9 +394,6 @@ GLT_API void gltEndDraw()
     glUniformMatrix4fv(_gltText2DShaderMVPUniformLocation, 1, GL_FALSE, mvp);                                          \
                                                                                                                        \
     glBindVertexArray(text->_vao);                                                                                     \
-                                                                                                                       \
-    glBindVertexArray(text->_vao);                                                                                     \
-                                                                                                                       \
     glBindBuffer(GL_ARRAY_BUFFER, text->_vbo);                                                                         \
                                                                                                                        \
     glEnableVertexAttribArray(_GLT_TEXT2D_POSITION_LOCATION);                                                          \

--- a/gltext.h
+++ b/gltext.h
@@ -390,11 +390,25 @@ GLT_API void gltEndDraw()
 
 }
 
-#define _gltDrawText() \
-	glUniformMatrix4fv(_gltText2DShaderMVPUniformLocation, 1, GL_FALSE, mvp); \
-	\
-	glBindVertexArray(text->_vao); \
-	glDrawArrays(GL_TRIANGLES, 0, text->vertexCount);
+#define _gltDrawText()                                                                                                 \
+    glUniformMatrix4fv(_gltText2DShaderMVPUniformLocation, 1, GL_FALSE, mvp);                                          \
+                                                                                                                       \
+    glBindVertexArray(text->_vao);                                                                                     \
+                                                                                                                       \
+    glBindVertexArray(text->_vao);                                                                                     \
+                                                                                                                       \
+    glBindBuffer(GL_ARRAY_BUFFER, text->_vbo);                                                                         \
+                                                                                                                       \
+    glEnableVertexAttribArray(_GLT_TEXT2D_POSITION_LOCATION);                                                          \
+    glVertexAttribPointer(_GLT_TEXT2D_POSITION_LOCATION, _GLT_TEXT2D_POSITION_SIZE, GL_FLOAT, GL_FALSE,                \
+                          (_GLT_TEXT2D_VERTEX_SIZE * sizeof(GLfloat)),                                                 \
+                          (const void*)(_GLT_TEXT2D_POSITION_OFFSET * sizeof(GLfloat)));                               \
+                                                                                                                       \
+    glEnableVertexAttribArray(_GLT_TEXT2D_TEXCOORD_LOCATION);                                                          \
+    glVertexAttribPointer(_GLT_TEXT2D_TEXCOORD_LOCATION, _GLT_TEXT2D_TEXCOORD_SIZE, GL_FLOAT, GL_FALSE,                \
+                          (_GLT_TEXT2D_VERTEX_SIZE * sizeof(GLfloat)),                                                 \
+                          (const void*)(_GLT_TEXT2D_TEXCOORD_OFFSET * sizeof(GLfloat)));                               \
+    glDrawArrays(GL_TRIANGLES, 0, text->vertexCount);
 
 GLT_API void gltDrawText(GLTtext *text, const GLfloat mvp[16])
 {


### PR DESCRIPTION
glVertexAttribPointer is set when gltCreateText is called.  If the text pointer is cached over multiple frames, and some other drawing code modifies glVertexAttribPointer between creating the text and drawing the text, then the resulting text draw is extremely garbled and incorrect.  

glVertexAttribPointer must be set for the text draw before drawing.  It cannot be stored at creation time.  